### PR TITLE
fix: `react-qr-reader` as peer dependency

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "app": "0.2.15",
   "packages/assets": "0.1.35",
   "packages/cloud-core": "1.0.48",
-  "packages/cloud-react": "0.1.130",
+  "packages/cloud-react": "0.1.131",
   "packages/utils": "0.0.25"
 }

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
@@ -26,11 +26,6 @@
     "postbuild": "node ./scripts/postbuild.mjs",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
-  "peerDependencies": {
-    "framer-motion": "^10.16.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "dependencies": {
     "@chainsafe/metamask-polkadot-adapter": "^0.5.1",
     "@chainsafe/metamask-polkadot-types": "^0.6.0",
@@ -50,7 +45,12 @@
     "buffer": "^6.0.3",
     "framer-motion": "^10.16.5",
     "qrcode-generator": "^1.4.4",
-    "react-error-boundary": "^4.0.11",
+    "react-error-boundary": "^4.0.11"
+  },
+  "peerDependencies": {
+    "framer-motion": "^10.16.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-qr-reader": "^2.2.1"
   }
 }


### PR DESCRIPTION
Having `react-qr-reader` was causing multiple versions of React to exist in projects further downstream, which was causing their builds to fail.